### PR TITLE
Derive `Clone` for `futures::MockStream`

### DIFF
--- a/src/mock_stream/futures.rs
+++ b/src/mock_stream/futures.rs
@@ -22,7 +22,7 @@ macro_rules! ready {
 
 pin_project! {
     /// Asynchronous mock IO stream
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub struct MockStream {
         #[pin]
         read_half: ReadHalf,
@@ -98,7 +98,7 @@ impl AsyncWrite for MockStream {
 }
 
 /// Read half of asynchronous mock IO stream
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ReadHalf {
     receiver: Receiver<Vec<u8>>,
     remaining: Vec<u8>,


### PR DESCRIPTION
Derive `Clone` implementations for `MockStream` and `ReadHalf` to allow the mock stream to be used to test async methods with take a stream of type `T` where `T: AsyncRead + AsyncWrite + Clone + Unpin + Send + Sync + 'static`.